### PR TITLE
changing around a few sponsor section styles, making the logo section…

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -143,7 +143,7 @@ header {
 }
 
 @media only screen and (max-width : 1250px) {
-	.title > h1 { 
+	.title > h1 {
 		font-size: 28px;
 	 }
 }
@@ -357,6 +357,52 @@ ul > li > a {
 }
 
 /*
+ * Sponsors
+ */
+
+ @media only screen and (max-width: 560px) {
+ 	.sponsor-section {
+ 		margin: 0px !important;
+ 	}
+ }
+
+.sponsor-section {
+	padding: 5%;
+ 	text-align: center;
+	margin: 5% 20%;
+	background-color: rgba(0, 0, 0, 0.2);
+}
+
+.sponsor-section img {
+ 	max-width:100%;
+ 	max-height:100%;
+ 	display: block;
+ 	margin-left: auto;
+ 	margin-right: auto;
+ 	padding-left: 15px;
+ 	padding-right: 15px;
+}
+
+.sponsor-section .row div {
+ 	/*height: 100%;*/
+}
+
+.sponsor-section img:hover {
+ 	/*width: 300px;*/
+}
+
+.high-tier img {
+ 	width: 300px !important;
+}
+
+.sponsor-section h1 {
+ 	margin-left: auto;
+ 	margin-right: auto;
+ 	text-align: center;
+ 	margin-bottom: 50px;
+}
+
+/*
  * Footer
  */
 
@@ -413,46 +459,6 @@ body {
 }
 #speakers {
 	background-color: rgba(255, 0, 0, 1);
-}
-@media only screen and (max-width: 560px) {
-	#sponsors {
-		margin: 0px !important;
-	}
-}
-#sponsors {
-	/*background-color: rgba(0, 0, 0, 1);*/
-	/*color: black;*/
-	text-align: center;
-	margin: 50px;
-}
-#sponsors img {
-	max-width:100%;
-	max-height:100%;
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
-
-	padding-left: 15px;
-	padding-right: 15px;
-	/*width: 200px;*/
-	/*padding: 20px;*/
-	/*vertical-align: center;*/
-	/*text-align: center;*/
-}
-#sponsors .row div {
-	/*height: 100%;*/
-}
-#sponsors img:hover {
-	/*width: 300px;*/
-}
-.high-tier img {
-	width: 300px !important;
-}
-#sponsors h1 {
-	margin-left: auto;
-	margin-right: auto;
-	text-align: center;
-	margin-bottom: 50px;
 }
 
 #subtitle {

--- a/index.html
+++ b/index.html
@@ -259,8 +259,7 @@
 			<h1>speakers</h1>
 		</section>
 
-		<section class="row section" id="sponsors">
-			<h1>Our Sponsors:</h1>
+		<section class="row section sponsor-section" id="sponsors">
 			<table style="width: 100%;">
 				<tr>
 					<th colspan="6"><img src="assets/img/logos/google.png"></th>


### PR DESCRIPTION
… a bit skinnier, and adding an opaque black background.

<img width="1180" alt="screen shot 2016-07-21 at 11 55 14 pm" src="https://cloud.githubusercontent.com/assets/5349493/17048967/c141f3a6-4f9e-11e6-8c05-38b725021477.png">
