### PR TITLE
links not clickable on mobile fix

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -258,6 +258,7 @@ ul > li > a {
 	aside {
 		align-items: flex-start;
 		width: 100%;
+		height: 0;
 	}
 
 	.mobile {


### PR DESCRIPTION
one liner fix for speaker links (maybe other links as well) not being clickable on mobile