### PR TITLE
Increase size of social media links on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,16 +52,16 @@
 					<h4>September 29th - October 1st</h4>
 					<ul class="social-media-icons">
 						<li>
-							<a href="https://twitter.com/acmreflections" class="fa fa-twitter icon_link"><i class="label"></i></a>
+							<a href="https://twitter.com/acmreflections" class="fa fa-2x fa-twitter icon_link"><i class="label"></i></a>
 						</li>
 						<li>
-							<a href="https://www.youtube.com/channel/UCm5h-rixlNgYL1PoFPJjYog" class="fa fa-youtube icon_link"><i class="label"></i></a>
+							<a href="https://www.youtube.com/channel/UCm5h-rixlNgYL1PoFPJjYog" class="fa fa-2x fa-youtube icon_link"><i class="label"></i></a>
 						</li>
 						<li>
-							<a href="https://www.facebook.com/acmrp" class="fa fa-facebook icon_link"><i class="label"></i></a>
+							<a href="https://www.facebook.com/acmrp" class="fa fa-2x fa-facebook icon_link"><i class="label"></i></a>
 						</li>
 						<li>
-							<a href="mailto:conference-chair@acm.uiuc.edu" class="fa fa-envelope-o icon_link"><i class="label"></i></a>
+							<a href="mailto:conference-chair@acm.uiuc.edu" class="fa fa-2x fa-envelope-o icon_link"><i class="label"></i></a>
 						</li>
 					</ul>
 					<div style="margin-top:20px">


### PR DESCRIPTION
Added the `fa-2x` class on the icons to make them a bit bigger. Looks like this now:

<img width="1680" alt="screen shot 2016-09-12 at 9 02 02 pm" src="https://cloud.githubusercontent.com/assets/3608224/18459065/36b988a4-792c-11e6-8f87-3253ca5f536c.png">

`fa-3x` seemed a bit too big, but let me know if we needed them to be bigger.