### PR TITLE
Add facebook event links for scheduled events on site

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,21 +222,21 @@
 					<tr>
 						<td>12:00pm - 1:00pm</td>
 						<td>
-							Startup Panel
+							Startup Panel <a href="https://www.facebook.com/events/1029203237196545/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 2405</span>
 						</td>
 					</tr>
 					<tr>
 						<td>&nbsp 2:00pm - 5:30pm</td>
 						<td>
-							<a href="/startupfair">Startup Fair</a>
+							<a href="/startupfair">Startup Fair</a> <a href="https://www.facebook.com/events/802754333199809/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Atrium</span>
 						</td>
 					</tr>
 					<tr>
 						<td>&nbsp 6:00pm - 6:50pm</td>
 						<td>
-							Speaker: <a href="#benjun">Ben Jun</a>
+							Speaker: <a href="#benjun">Ben Jun</a> <a href="https://www.facebook.com/events/304257443273092/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
@@ -260,7 +260,7 @@
 					<tr>
 						<td>&nbsp 10:30am - 4:30pm</td>
 						<td>
-							<a href="/jobfair">Job Fair</a>
+							<a href="/jobfair">Job Fair</a> <a href="https://www.facebook.com/events/1751680491761527/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Atrium</span>
 						</td>
 					</tr>
@@ -274,7 +274,7 @@
 					<tr>
 						<td>&nbsp 7:30pm - 8:20pm</td>
 						<td>
-							Keynote Speaker: <a href="#basil">Basil Alwan</a>
+							Keynote Speaker: <a href="#basil">Basil Alwan</a> <a href="https://www.facebook.com/events/1646567469007213/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
@@ -288,7 +288,7 @@
 					<tr>
 						<td>&nbsp 9:00pm</td>
 						<td>
-							MechMania Kickoff
+							MechMania Kickoff <a href="https://www.facebook.com/events/179283609177533/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel Center</span>
 						</td>
 					</tr>
@@ -307,14 +307,14 @@
 					<tr>
 						<td>&nbsp 10:00am - 10:50am</td>
 						<td>
-							Speaker: <a href="#santanu">Santanu Kolay</a>
+							Speaker: <a href="#santanu">Santanu Kolay</a> <a href="https://www.facebook.com/events/1768331856775762/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
 					<tr>
 						<td>&nbsp 11:00am - 11:50am</td>
 						<td>
-							Speaker: <a href="#laura">Laura Gómez</a>
+							Speaker: <a href="#laura">Laura Gómez</a> <a href="https://www.facebook.com/events/1790826274496409/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
@@ -328,14 +328,14 @@
 					<tr>
 						<td>&nbsp 1:00pm - 1:50pm</td>
 						<td>
-							Speaker: <a href="#nicole">Nicole Hu</a>
+							Speaker: <a href="#nicole">Nicole Hu</a> <a href="https://www.facebook.com/events/1753615924897924/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
 					<tr>
 						<td>&nbsp 2:00pm - 2:50pm</td>
 						<td>
-							Speaker: <a href="#don">Don Dini</a>
+							Speaker: <a href="#don">Don Dini</a> <a href="https://www.facebook.com/events/1169816243076236/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
@@ -349,14 +349,14 @@
 					<tr>
 						<td>&nbsp 4:00pm - 4:50pm</td>
 						<td>
-							Speakers: <a href="#maesen">Maesen Churchill</a> &amp; <a href="#grace">Grace Huang</a>
+							Speakers: <a href="#maesen">Maesen Churchill</a> &amp; <a href="#grace">Grace Huang</a> <a href="https://www.facebook.com/events/1261193603911288/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
 					<tr>
 						<td>&nbsp 5:00pm - 5:50pm</td>
 						<td>
-							Speaker: <a href="#clare">Clare Curtis</a>
+							Speaker: <a href="#clare">Clare Curtis</a> <a href="https://www.facebook.com/events/1661707850807627/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>
@@ -370,7 +370,7 @@
 					<tr>
 						<td>&nbsp 7:00pm - 7:50pm</td>
 						<td>
-							Speaker: <a href="#brad">Brad Nicholas</a>
+							Speaker: <a href="#brad">Brad Nicholas</a> <a href="https://www.facebook.com/events/1790213597883813/" class="fa fa-facebook icon_link"><i class="label"></i></a>
 							<span>Siebel 1404</span>
 						</td>
 					</tr>


### PR DESCRIPTION
Addresses #242 

This currently uses the facebook 'f' logo as clickable icons inline with every event that links to the corresponding facebook event. we can switch this over to another font awesome icon if needed. (I prefer the current facebook 'f', but I'd recommend http://fontawesome.io/icon/calendar-o/ as a secondary option)